### PR TITLE
Incoming ships sorted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+assets
+local.html
+resources.json

--- a/buildingSpacePort.js
+++ b/buildingSpacePort.js
@@ -493,6 +493,18 @@ if (typeof YAHOO.lacuna.buildings.SpacePort == "undefined" || !YAHOO.lacuna.buil
 		ForeignPopulate : function() {
 			var details = Dom.get("shipsForeignDetails");
 			
+            ships.sort(function(a,b) {
+                if (a.date_arrives > b.date_arrives) {
+                    return 1;
+                }
+                else if (a.date_arrives < b.arrives) {
+                    return -1;
+                }
+                else {
+                    return 0;
+                }
+            });
+
 			if(details) {
 				var ships = this.shipsForeign.ships,
 					ul = document.createElement("ul"),

--- a/notify.js
+++ b/notify.js
@@ -98,6 +98,18 @@ if (typeof YAHOO.lacuna.Notify == "undefined" || !YAHOO.lacuna.Notify) {
 			var incoming = planet.incoming_foreign_ships || [],
 				planetShips = this.incomingShips[planet.id] || [];
 			
+            incoming.sort(function(a,b) {
+                if (a.date_arrives > b.date_arrives) {
+                    return 1;
+                }
+                else if (a.date_arrives < b.arrives) {
+                    return -1;
+                }
+                else {
+                    return 0;
+                }
+            });
+			
 			if(planetShips.length != incoming.length) {
 				this._createDisplay();
 				this.incomingShips[planet.id] = incoming;


### PR DESCRIPTION
I've always thought that the incoming ship lists should be sorted by arrival time with the soonest arrival at the top. This commit does just that for both the on-screen planet display and the Space Port Incoming tab.
