### PR TITLE
Recipients list

### DIFF
--- a/messaging.js
+++ b/messaging.js
@@ -107,6 +107,7 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 				this.timestamp = Dom.get("messagingTimestamp");
 				this.from = Dom.get("messagingFrom");
 				this.to = Dom.get("messagingTo");
+				this.recipients = Dom.get("messagingRecipients");
 				this.subject = Dom.get("messagingSubject");
 				this.body = Dom.get("messagingBody");
 				this.display = Dom.get("messagingDisplay");
@@ -615,6 +616,14 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 				this.timestamp.innerHTML = Lib.formatServerDate(msg.date);
 				this.from.innerHTML = ['<a class="profile_link" href="#',msg.from_id,'">',msg.from,'</a>'].join('');
 				this.to.innerHTML = ['<a class="profile_link" href="#',msg.to_id,'">',msg.to,'</a>'].join('');
+
+                if(msg.recipients.length > 1) {
+                    var rec = msg.recipients;
+                    recDiv = this.to.parentNode.appendChild(document.createElement("div"));
+                    recDiv.id = "recipientsList";
+                    recDiv.innerHTML = ['<label>Recipients:</label><span id="messagingRecipients">',msg.recipients.join(", "),'</span>'].join('');
+                }
+
 				this.subject.innerHTML = msg.subject;
 				this.body.parentNode.scrollTop = 0;
 				this.body.innerHTML = msg.body ? this.formatBody(msg.body) : '';

--- a/styles.css
+++ b/styles.css
@@ -692,7 +692,7 @@ body.yui-skin-sam .yui-pg-container .yui-pg-current-page {
 	background-color:#D2D2D2;
 	display:inline-block;
 	font-weight:bold;
-	width:75px;
+	width:82px;
 	color:#000;
 }
 #messagingDisplay div, #messagingCreator div.messagingCreatorC {


### PR DESCRIPTION
It is confusing when a message is sent to multiple people because the GUI does not show this. Often people will simply reply instead of replying to all interested parties.

This commit attempts to notify the recipient that a message was addressed to multiple people. 

If a message is addressed to multiple recipients, a Recipients: field will be added, directly below the To: field, with a comma separated list of recipients in it. The size of "Recipients:" also required a change to the width of the #messagingDisplay label.
