### PR TITLE
Alt filter messages

### DIFF
--- a/messaging.js
+++ b/messaging.js
@@ -32,10 +32,6 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 				'	<div id="messagingTabs" class="yui-navset"><ul class="yui-nav">',
 				'		<li id="messagingCreate" class="tab"><a href="#"><em>Create</em></a></li>',
 				'		<li id="messagingInbox" class="tab"><a href="#"><em>Inbox</em></a></li>',
-				'		<li id="messagingAlerts" class="tab"><a href="#"><em>Alerts</em></a></li>',
-				'		<li id="messagingIntel" class="tab"><a href="#"><em>Intel</em></a></li>',
-				'		<li id="messagingMedals" class="tab"><a href="#"><em>Medals</em></a></li>',
-				'		<li id="messagingTutorial" class="tab"><a href="#"><em>Tutorial</em></a></li>',
 				'		<li id="messagingSent" class="tab"><a href="#"><em>Sent</em></a></li>',
 				'		<li id="messagingArchive" class="tab"><a href="#"><em>Archive</em></a></li>',
 				'		<li id="messagingAnnounce" class="tab"><a href="#"><em>Announcement</em></a></li>',
@@ -50,11 +46,18 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 				'			</div>',
 				'		</div>',
 				'		<div id="messagingReader" class="panelTabContainer yui-gd">',
+				'			<div id="messagingArchiver">',
+				'				<button id="messagingArchiveSelected" type="button">Archive</button>',
+				'				<button id="messagingSelectAll" type="button">Select All</button>',
+                '               <select id="inboxTag">',
+                '                   <option value="Correspondence">Inbox</option>',
+                '                   <option value="Alert">Alerts</option>',
+                '                   <option value="Intelligence">Intel</option>',
+                '                   <option value="Medal">Medals</option>',
+                '                   <option value="Tutorial">Tutorial</option>',
+                '               </select>',
+				'			</div>',
 				'			<div class="yui-u first" style="height: 400px; overflow-y: auto;border-right: 1px solid gray;position:relative;" >',
-				'				<div id="messagingArchiver">',
-				'					<button id="messagingArchiveSelected" type="button">Archive</button>',
-				'					<button id="messagingSelectAll" type="button">Select All</button>',
-				'				</div>',
 				'				<div id="messagingPaginator">',
 				'				</div>',
 				'				<ul id="messagingList"></ul>',
@@ -94,21 +97,13 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 				width:"700px",
 				zIndex:9999
 			});
-			this.tab2tag = {
-                messagingInbox : 'Correspondence',
-                messagingAlerts : 'Alert',
-                messagingIntel : 'Intelligence',
-                messagingMedals : 'Medal',
-                messagingTutorial : 'Tutorial',
-            };
 			this.messagingPanel.renderEvent.subscribe(function(){
 				//tabs
 				this.create = Dom.get("messagingCreate");
 				this.inbox = Dom.get("messagingInbox");
-				this.alerts = Dom.get("messagingAlerts");
-				this.intel = Dom.get("messagingIntel");
-				this.medals = Dom.get("messagingMedals");
-				this.tutorial = Dom.get("messagingTutorial");
+                this.inboxTag = Dom.get("inboxTag");
+                this.tag = this.inboxTag.options[this.inboxTag.selectedIndex].value;
+                Event.on("inboxTag", "change", this.updateTag, this, true);
 				this.sent = Dom.get("messagingSent");
 				this.archive = Dom.get("messagingArchive");
 				this.announce = Dom.get("messagingAnnounce");
@@ -313,7 +308,7 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 					break;
 				default:
 					Dom.setStyle(this.archiver,"display","");
-					this.loadInboxMessages(this.currentTab);
+					this.loadInboxMessages();
 					break;
 			}
 		},
@@ -344,15 +339,17 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 			}
 			this._setTab(this.create);
 		},
-		loadInboxMessages : function(tab) {
-			this._setTab(tab);
+        updateTag : function() {
+            this.tag = this.inboxTag.options[this.inboxTag.selectedIndex].value;
+            this.loadInboxMessages();
+        },
+		loadInboxMessages : function() {
+			this._setTab(this.inbox);
 			if(this.pager) {this.pager.destroy();}
-			
 			var InboxServ = Game.Services.Inbox,
-                tag = this.tab2tag[tab];
 				data = {
 					session_id: Game.GetSession(""),
-					options:{page_number: 1, tags: [tag]}
+					options:{page_number: 1, tags: [this.tag]}
 				};
 			InboxServ.view_inbox(data, {
 				success : function(o){
@@ -450,7 +447,7 @@ if (typeof YAHOO.lacuna.Messaging == "undefined" || !YAHOO.lacuna.Messaging) {
 			var InboxServ = Game.Services.Inbox,
 				data = {
 					session_id: Game.GetSession(""),
-					options:{page_number: newState.page}
+					options:{page_number: newState.page, tags: [this.tag]}
 				};
 			InboxServ.view_inbox(data, {
 				success : function(o){


### PR DESCRIPTION
This is a similar but different approach to Filter Messages https://github.com/plainblack/Lacuna-Web-Client/pull/4.

It adds a select box to the messagingArchiver that allows the player to select the type of messages to display in the Inbox. It also moves the messagingArchiver div outside of the div containing the messagingPaginator and messagingList to improve the look (at the expense of some vertical real estate in the messagingDisplay.

(After the push to github, I noticed that it was using spaces in place of tabs; sorry about that.)
