### PR TITLE
Fix stash minus

### DIFF
--- a/buildingEmbassy.js
+++ b/buildingEmbassy.js
@@ -437,7 +437,7 @@ if (typeof YAHOO.lacuna.buildings.Embassy == "undefined" || !YAHOO.lacuna.buildi
 				li = matchedEl.parentNode.parentNode;
 			if(quantity) {
 				var newTotal = li.Object.quantity - quantity,
-					diff = quantity,
+					diff = quantity*-1,
 					lq = Sel.query(".quantity", li, true);;
 				if(newTotal < 0) {
 					newTotal = 0;


### PR DESCRIPTION
This is a display issue only.

Pressing the minus button in the Stash Exchange increments the Total instead of decrementing it.

http://community.lacunaexpanse.com/forums/support/stash-exchange-minus-button
