### PR TITLE
Close dev min on subsidize

### DIFF
--- a/buildingDevelopment.js
+++ b/buildingDevelopment.js
@@ -113,6 +113,9 @@ if (typeof YAHOO.lacuna.buildings.Development == "undefined" || !YAHOO.lacuna.bu
 						this.removeTab(this.queueTab);
 					}
 					
+					//close buildingDetails
+					this.fireEvent("onHide");
+
 					//refresh map
 					this.fireEvent("onUpdateMap");
 				},


### PR DESCRIPTION
"The development ministry panel should close once an upgrade has been subsidized."
http://community.lacunaexpanse.com/forums/ideas/development-ministry2

I know that I've wasted resources on many occasions by doing this.
