### PR TITLE
Push default planet

### DIFF
--- a/buildingTradeMinistry.js
+++ b/buildingTradeMinistry.js
@@ -190,7 +190,7 @@ if (typeof YAHOO.lacuna.buildings.Trade == "undefined" || !YAHOO.lacuna.building
 			'</div>',
 			'<ul style="margin-top:5px;">',
 			'	<li style=""><label>Total Cargo:</label><span id="tradePushCargo">0</span></li>',
-			'	<li style="margin-bottom:5px;"><label>To Colony:</label><select id="tradePushColony"></select></li>',
+			'	<li style="margin-bottom:5px;"><label>To Colony:</label><select id="tradePushColony"><option value="" selected>&nbsp;</option></select></li>',
 			'	<li style="margin-bottom:5px;"><label>With Ship:</label><select id="tradePushShip"></select></li>',
 			'	<li style="margin-bottom:5px;"><label>Stay at Colony:</label><input type="checkbox" id="tradePushStay" /></li>',
 			'	<li id="tradePushMessage" class="alert"></li>',
@@ -208,6 +208,7 @@ if (typeof YAHOO.lacuna.buildings.Trade == "undefined" || !YAHOO.lacuna.building
 					planets = Game.EmpireData.planets,
 					cp = Game.GetCurrentPlanet(),
 					nOpt;
+                planets = Lib.planetarySort(planets);
 				for(var pId in planets) {
 					if(planets.hasOwnProperty(pId) && pId != cp.id){
 						nOpt = opt.cloneNode(false);

--- a/buildingTransporter.js
+++ b/buildingTransporter.js
@@ -241,7 +241,7 @@ if (typeof YAHOO.lacuna.buildings.Transporter == "undefined" || !YAHOO.lacuna.bu
 			'</div>',
 			'<ul style="margin-top:5px;">',
 			'	<li style=""><label>Total Cargo:</label><span id="tradePushCargo">0</span></li>',
-			'	<li style="margin-bottom:5px;"><label>To Colony:</label><select id="tradePushColony"></select></li>',
+			'	<li style="margin-bottom:5px;"><label>To Colony:</label><select id="tradePushColony"><option value="" selected>&nbsp;</option></select></li>',
 			'	<li id="tradePushMessage" class="alert"></li>',
 			'	<li><button id="tradePushSend">',this.pushTradeText,'</button></li>',
 			'</ul>'].join('')});
@@ -257,6 +257,7 @@ if (typeof YAHOO.lacuna.buildings.Transporter == "undefined" || !YAHOO.lacuna.bu
 					planets = Game.EmpireData.planets,
 					cp = Game.GetCurrentPlanet(),
 					nOpt;
+                planets = Lib.planetarySort(planets);
 				for(var pId in planets) {
 					if(planets.hasOwnProperty(pId) && pId != cp.id){
 						nOpt = opt.cloneNode(false);

--- a/library.js
+++ b/library.js
@@ -302,7 +302,28 @@ if (typeof YAHOO.lacuna.Library == "undefined" || !YAHOO.lacuna.Library) {
 			spy_pod:"Spy Pod",
 			spy_shuttle:"Spy Shuttle",
 			terraforming_platform_ship:"Terraforming Platform Ship"
-		}
+		},
+
+        // planetarySort - Input: Game.EmpireData.planets, Output: A sorted array of planetary objects
+        planetarySort : function(planets) {
+            var newplanets = Array();
+            for(var pId in planets) {
+                newplanets.push(planets[pId]);
+            }
+            planets = newplanets.sort(function(a,b) {
+                    if (a.name > b.name) {
+                        return 1;
+                    }
+                    else if (a.name < b.name) {
+                        return -1;
+                    }
+                    else {
+                        return 0;
+                    }
+            });
+            return planets;
+        }
+
 	};
 	
 	YAHOO.lacuna.Library = Library;


### PR DESCRIPTION
http://community.lacunaexpanse.com/forums/ideas/trademin-push

This adds a blank option to the To Colony select box on the Push tab of the Trade Min and SST. 

It also adds a planetarySort function to the library that sorts the planets by name. This function gets used when building the To Colony select box in both places. 

library.js seemed like the best option but I also considered adding a trade specific library. (If this location is good, I will start moving other duplicated functions here.)
