### PR TITLE
Support double clicking on glyphs  in addition to D&D

### DIFF
--- a/buildingArchaeology.js
+++ b/buildingArchaeology.js
@@ -286,6 +286,17 @@ if (typeof YAHOO.lacuna.buildings.Archaeology == "undefined" || !YAHOO.lacuna.bu
 						'</div>'
 					].join('');
 					
+					Event.on(nLi, "dblclick", function(ev) { 
+						var id = this.parentNode.id;
+						var destCont;
+						if (id == "archaeologyGlyphDetails") {
+							destCont = Dom.get("archaeologyGlyphCombine");
+						}
+						else if (id == "archaeologyGlyphCombine") {
+							destCont = Dom.get("archaeologyGlyphDetails");
+						}
+						destCont.appendChild(this);
+					});
 					nLi = details.appendChild(nLi);
 					nLi.DD = new DDList(nLi);
 				}


### PR DESCRIPTION
A simple little change to support double clicking a glyph to add it to the combine box.

I've personally had a lot of issue getting the dropping working right, and trying it out on my dev server this is a lot simpler.

Let me know if i should change anything, I'm not all that comfortable with YUI yet, but I'm thinking the event should be higher up and delegated.
