### PR TITLE
Quickie nodejs server for development

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var path = require('path');
+
+var express = require('express');
+var app = express();
+
+var port = process.env.PORT || 80;
+
+app.use('/lacuna', express.static(path.join(__dirname, '..')));
+
+app.listen(port, function() {
+  console.log('Listening on http://localhost:' + port + ' for requests.');
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "server",
+  "version": "0.1.0",
+  "description": "Quick server to serve the files required to run the client.",
+  "main": "index.js",
+  "author": "Nathan McCallum <onevasari@gmail.com> (https://github.com/1vasari)",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.12.3"
+  }
+}


### PR DESCRIPTION
This is just a quick server implemented with node.js that serves the code on the `/lacuna` route.

It depends on [node.js](https://nodejs.org) which you just need to download and install or do whatever you do with your package manager. Once you've done that, cd in the server directory and run `npm install`. This will install express which the server needs.

Once you have all that, from the route of the repo run, `node server` and you'll have a server running. If you go to the [US1 local mirror](http://us1.lacunaexpanse.com/local.html) you'll see the game load up.

I couldn't find anything that explained how this is meant to be done so I just hacked this together so that I don't have to configure a web server or some :shit: like that. :grinning: 