### PR TITLE
Make builds quicker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 # Ignore npm-debug.log.
 *.log
 
+# Modules downloaded by npm.
 node_modules/
+
+# Built JS and CSS files.
 lacuna/
+
+# Cache to speed up the build process.
+browserify-cache.json
+
+
+
 index.html

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -13,6 +13,8 @@ var uglify = require('gulp-uglify');
 var path = require('path');
 var express = require('express');
 
+var del = require('del');
+
 gulp.task('dev', ['browserify', 'cssify', 'serve'], function() {
 
     var watcher = gulp.watch('./app/**/*', ['browserify', 'cssify']);
@@ -85,6 +87,16 @@ gulp.task('serve', ['browserify', 'cssify'], function(done) {
       console.log('Listening on http://localhost:' + port + ' for requests.');
       done();
     });
+});
+
+gulp.task('clean', function() {
+    var files = [
+        'browserify-cache.json',
+        'lacuna/*.js',
+        'lacuna/*.css'
+    ];
+
+    del.sync(files);
 });
 
 // The default task is a build of everything.

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var browserify = require('browserify');
+var browserifyInc = require('browserify-incremental');
 var reactify = require('reactify');
-var source     = require('vinyl-source-stream');
+var source = require('vinyl-source-stream');
 
 var cssConcat = require('gulp-concat-css');
-var cssMin    = require('gulp-minify-css');
-var gulp      = require('gulp');
-var rename    = require('gulp-rename');
-var uglify    = require('gulp-uglify');
+var cssMin = require('gulp-minify-css');
+var gulp = require('gulp');
+var rename = require('gulp-rename');
+var uglify = require('gulp-uglify');
 
-var path    = require('path');
+var path = require('path');
 var express = require('express');
 
 gulp.task('dev', ['browserify', 'cssify', 'serve'], function() {
@@ -29,17 +29,10 @@ gulp.task('dev', ['browserify', 'cssify', 'serve'], function() {
 });
 
 gulp.task('browserify', function() {
-    var b = browserify(['./app/js/load.js'], {
-        noParse: [
-            'jquery'
-        ],
-        extensions: [
-            // Include React files in the bundle.
-            '.jsx'
-        ],
-        paths: [
-            path.join(__dirname, 'app')
-        ]
+    var b = browserifyInc(['./app/js/load.js'], {
+        extensions: ['.jsx'],
+        paths: [path.join(__dirname, 'app')],
+        cachefile: path.join(__dirname, 'browserify-cache.json')
     });
 
     // This transforms all the .jsx files into JavaScript.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ In this project, Gulp is used to manage building the code. All the tasks that ca
 
 > `gulp build`
 
-Runs the entire process of pulling all the JavaScript/CSS together and creates minified versions of them. This is also the default task, meaning that running just `gulp` in the command line will run this task.
+Runs the entire process of pulling all the JavaScript/CSS together and creates minified versions of them. This is the default task, meaning that running just `gulp` in the command line will run this task.
 
 ## dev
 
@@ -222,3 +222,9 @@ This puts all the JavaScript and CSS together and starts a web server to run the
 > `gulp serve`
 
 This just runs the server for running the client in a browser.
+
+## clear
+
+> `gulp clear`
+
+This deletes temporary files and files from the build.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "browserify": "11.2.0",
     "browserify-incremental": "3.0.1",
     "classnames": "2.1.2",
-    "del": "^2.0.2",
+    "del": "2.0.2",
     "express": "4.12.4",
     "firebase": "2.2.7",
     "gulp": "3.9.0",
@@ -33,7 +33,6 @@
     "react-tooltip": "0.6.4",
     "reactify": "1.1.0",
     "reflux": "0.2.7",
-    "trash": "^3.1.1",
     "vinyl-source-stream": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "browserify": "11.2.0",
     "browserify-incremental": "3.0.1",
     "classnames": "2.1.2",
+    "del": "^2.0.2",
     "express": "4.12.4",
     "firebase": "2.2.7",
     "gulp": "3.9.0",
@@ -32,6 +33,7 @@
     "react-tooltip": "0.6.4",
     "reactify": "1.1.0",
     "reflux": "0.2.7",
+    "trash": "^3.1.1",
     "vinyl-source-stream": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://lacunaexpanse.com/",
   "dependencies": {
-    "browserify": "10.2.3",
+    "browserify": "11.2.0",
+    "browserify-incremental": "3.0.1",
     "classnames": "2.1.2",
     "express": "4.12.4",
     "firebase": "2.2.7",


### PR DESCRIPTION
This PR implements a cache so that Browserify doesn't recompile the entire code base every build. I do all my development work on a two-year-old laptop that was bought on a high school budget. Despite that, this change reduces the build time on my machine significantly. 

The very first time you run `gulp dev` it will take the "normal" time to build. After that, the cache file will have been created and every subsequent build will be a lot quicker. As can be seen below.

![Build Output](http://puu.sh/kPgyP/8aebe08daa.png)

**Note:** If something messes up and you just want to clear everything and try again, run `gulp clean`.