### PR TITLE
Initial planet accordion

### DIFF
--- a/app/js/components/menu/rightSidebar.jsx
+++ b/app/js/components/menu/rightSidebar.jsx
@@ -13,14 +13,14 @@ var BodyRPCStore = require('js/stores/rpc/body');
 var RightSidebarActions = require('js/actions/menu/rightSidebar');
 var MapActions = require('js/actions/menu/map');
 
-var toggle = function(callback) {
-    return function() {
-        RightSidebarActions.toggle();
-        callback();
-    };
-}
-
 var PlanetListItem = React.createClass({
+
+    propTypes: {
+        name: React.PropTypes.string.isRequired,
+        id: React.PropTypes.string.isRequired,
+        current: React.PropTypes.string.isRequired
+    },
+
     getInitialProps: function() {
         return {
             name: '',
@@ -28,36 +28,46 @@ var PlanetListItem = React.createClass({
             current: '',
         };
     },
-    propTypes: {
-        name: React.PropTypes.string.isRequired,
-        id: React.PropTypes.string.isRequired
+
+    // Returns true if this list item is the the currently selected planet.
+    isCurrentWorld: function() {
+        return this.props.current === this.props.id
     },
+
     handleClick: function() {
-        console.log('Changing to planet (#' + this.props.id + ').');
         RightSidebarActions.toggle();
-        MapActions.changePlanet(this.props.id);
+
+        if (this.isCurrentWorld()) {
+            YAHOO.lacuna.MapPlanet.Refresh()
+        } else {
+            console.log('Changing to planet (#' + this.props.id + ').');
+            MapActions.changePlanet(this.props.id);
+        }
     },
+
     render: function() {
-        var current_world = this.props.current === this.props.id;
         var classStr = classNames({
-            'ui large teal label': current_world,
-            'item': !current_world
+            'ui large teal label': this.isCurrentWorld(),
+            'item': !this.isCurrentWorld()
         });
-        var refresh = current_world ? toggle(function() { YAHOO.lacuna.MapPlanet.Refresh() }) :
-                this.handleClick;
 
         return (
-                <a className={classStr} onClick={refresh} style={{
+            <a className={classStr} onClick={this.handleClick} style={{
                 // For some reason this doesn't get set on the items (by Semantic) when it should.
                 cursor: 'pointer'
             }}>
                 {this.props.name}
-                </a>
+            </a>
         );
     }
 });
 
 var BodyList = React.createClass({
+
+    propTypes: {
+        list: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+    },
+
     getInitialProps: function() {
         return {
             list: [],
@@ -65,24 +75,65 @@ var BodyList = React.createClass({
             title: '',
         };
     },
-    propTypes: {
-        list: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+
+    getInitialState: function() {
+        return {
+            open: false
+        };
     },
+
+    toggleList: function() {
+        this.setState({
+            open: !this.state.open
+        });
+    },
+
     render: function() {
         var list = [];
-        var bl = this;
 
         _.each(this.props.list, function(planet) {
             list.push(
-                <PlanetListItem key={planet.id}
+                <PlanetListItem
+                    key={planet.id}
                     name={planet.name}
                     id={planet.id}
-                    current={this.props.current} />
+                    current={this.props.current}
+                />
             );
         }, this);
 
-        return <div><div className="ui horizontal inverted divider">{this.props.title}</div>
-            <div>{list}</div></div>;
+        return (
+            <div>
+                <div
+                    className="ui horizontal inverted divider"
+                    title={
+                        this.state.open
+                        ? 'Click to hide ' + this.props.title.toLowerCase()
+                        : 'Click to show ' + this.props.title.toLowerCase()
+                    }
+                    onClick={this.toggleList}
+                    style={{
+                        cursor: 'pointer'
+                    }}
+                >
+                    {this.props.title}
+                </div>
+                <div
+                    style={{
+                        height: this.state.open ? window.innerHeight * 0.70 : 0,
+                        overflow: 'scroll',
+                        overflowX: 'hidden',
+
+                        // Taken from: https://davidwalsh.name/demo/css-slide.php
+                        transitionProperty: 'all',
+                        transitionDuration: '.5s',
+                        transitionTimingFunction: 'cubic-bezier(0, 1, 0.5, 1)'
+                    }}
+                >
+                    {list}
+                </div>
+            </div>
+        );
     }
 });
 
@@ -93,19 +144,29 @@ var RightSidebar = React.createClass({
     ],
 
     render: function() {
+        var items = [
+            ['My Colonies', 'colonies'],
+            ['My Stations', 'mystations'],
+            ['Our Stations', 'ourstations']
+        ];
+
+        var bodiesList = _.map(items, function(item) {
+            var list = this.state.empire.bodies[item[1]] || []
+
+            if (list.length > 0) {
+                return (
+                    <BodyList
+                        title={item[0]}
+                        list={list}
+                        current={this.state.body.id}
+                    />
+                );
+            }
+        }, this)
+
         return (
             <div className="ui right vertical inverted sidebar menu">
-
-                <BodyList title="My Colonies" list={this.state.empire.colonies} current={this.state.body.id} />
-
-                {
-                    this.state.empire.stations.length > 0 ?
-                        <div>
-                            <BodyList title="My Stations" list={this.state.empire.stations} current={this.state.body.id}/>
-                        </div>
-                    :
-                        ''
-                }
+                {bodiesList}
             </div>
         );
     }

--- a/app/js/components/menu/rightSidebar.jsx
+++ b/app/js/components/menu/rightSidebar.jsx
@@ -82,6 +82,25 @@ var BodyList = React.createClass({
         };
     },
 
+    componentDidMount: function() {
+        var $el = $(this.refs.list.getDOMNode());
+        $el.hide();
+    },
+
+    componentDidUpdate: function(prevProps, prevState) {
+        if (prevState.open === this.state.open) {
+            return;
+        }
+
+        var $el = $(this.refs.list.getDOMNode());
+
+        if (!$el.is(":visible") && this.state.open) {
+            $el.slideDown(500);
+        } else {
+            $el.slideUp(500);
+        }
+    },
+
     toggleList: function() {
         this.setState({
             open: !this.state.open
@@ -118,18 +137,7 @@ var BodyList = React.createClass({
                 >
                     {this.props.title}
                 </div>
-                <div
-                    style={{
-                        height: this.state.open ? window.innerHeight * 0.70 : 0,
-                        overflow: 'scroll',
-                        overflowX: 'hidden',
-
-                        // Taken from: https://davidwalsh.name/demo/css-slide.php
-                        transitionProperty: 'all',
-                        transitionDuration: '.5s',
-                        transitionTimingFunction: 'cubic-bezier(0, 1, 0.5, 1)'
-                    }}
-                >
+                <div ref="list">
                     {list}
                 </div>
             </div>

--- a/app/js/stores/rpc/empire/index.js
+++ b/app/js/stores/rpc/empire/index.js
@@ -34,6 +34,11 @@ var EmpireRPCStore = Reflux.createStore({
 
     getInitialState: function() {
         return {
+            bodies: {
+                colonies: [],
+                mystations: [],
+                ourstations: []
+            },
             colonies : [],
             essentia: 0,
             exactEssentia: 0,


### PR DESCRIPTION
I've hacked our own accordion-like system. It looks kinda nice, but it has a few things to work out:

- should we allow only one list open at a time?
- each item has a fixed height and handles scrolling itself - would it be better to kill all that and make the whole list scroll?
- handling authorized empires needs to be done (the necessary structure is already in place)

It all looks like this:

![planet menu](https://cloud.githubusercontent.com/assets/1539253/11626120/00553fce-9d2c-11e5-86f0-a4ab19f0712e.png)

The headers are clickable and they slide out their respective lists underneath.

**PS:** thanks to @tmtowtdi for giving me his password on PT a while back for testing thinks like this. :wink: 