### PR TITLE
Improvements to sidebar

### DIFF
--- a/app/js/actions/menu/leftSidebar.js
+++ b/app/js/actions/menu/leftSidebar.js
@@ -3,7 +3,8 @@
 var Reflux = require('reflux');
 
 var LeftSidebarActions = Reflux.createActions([
-    'toggle'
+    'show',
+    'hide'
 ]);
 
 module.exports = LeftSidebarActions;

--- a/app/js/actions/menu/rightSidebar.js
+++ b/app/js/actions/menu/rightSidebar.js
@@ -3,7 +3,9 @@
 var Reflux = require('reflux');
 
 var RightSidebarActions = Reflux.createActions([
-    'toggle',
+    'show',
+    'hide',
+
     'collapseAccordion',
     'expandAccordion'
 ]);

--- a/app/js/components/menu/leftSidebarButton.jsx
+++ b/app/js/components/menu/leftSidebarButton.jsx
@@ -14,7 +14,7 @@ var LeftSidebarButton = React.createClass({
     ],
 
     click: function() {
-        LeftSidebarActions.toggle();
+        LeftSidebarActions.show();
     },
 
     render: function() {

--- a/app/js/components/menu/rightSidebarButton.jsx
+++ b/app/js/components/menu/rightSidebarButton.jsx
@@ -14,7 +14,7 @@ var RightSidebarButton = React.createClass({
     ],
 
     click: function() {
-        RightSidebarActions.toggle();
+        RightSidebarActions.show();
     },
 
     render: function() {

--- a/app/js/components/window/index.jsx
+++ b/app/js/components/window/index.jsx
@@ -25,40 +25,43 @@ var StatsWindow = require('js/components/window/stats');
 var Window = React.createClass({
     render: function() {
         return (
-            <div>
-                { /*
-                    Semantic UI requires this structure for Sidebars to work.
-                    See: http://semantic-ui.com/modules/sidebar.html#/usage
-                 */ }
+            <div
+                id="sidebarContainer"
+                style={{
+                    position: 'fixed',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: '100%'
+                }}
+            >
+
                 <LeftSidebar />
                 <RightSidebar />
-
-                { /*
-                    This sets all the tooltips in the entire client.
-                    See http://npmjs.org/package/react-tooltip for usage.
-                */ }
-                <ReactTooltip
-                    effect="solid"
-                    place="bottom"
-                    type="dark"
-                />
 
                 { /* One container to rule them all... */ }
                 <div className="pusher">
 
-                    <Menu />
+                    { /*
+                        This sets all the tooltips in the entire client.
+                        See http://npmjs.org/package/react-tooltip for usage.
+                    */ }
+                    <ReactTooltip
+                        effect="solid"
+                        place="bottom"
+                        type="dark"
+                    />
 
+                    <Menu />
 
                     <Map />
                     <div id="content"></div> { /* This div is used by map. */ }
-
 
                     <WindowManager />
 
                     <MailWindow />
                     <OptionsWindow />
                     <StatsWindow />
-
                 </div>
             </div>
         );

--- a/app/js/stores/menu/leftSidebar.js
+++ b/app/js/stores/menu/leftSidebar.js
@@ -7,12 +7,19 @@ var LeftSidebarActions = require('js/actions/menu/leftSidebar');
 
 var LeftSidebarStore = Reflux.createStore({
     listenables: LeftSidebarActions,
-    onToggle: function() {
-        console.log('Toggling left sidebar.');
-        $('.ui.sidebar.left')
-            .sidebar('setting', 'transition', 'overlay')
-            .sidebar('setting', 'duration', 300)
-            .sidebar('toggle');
+
+    getInitialState: function() {
+        return false;
+    },
+
+    onShow: function() {
+        console.log('Showing left sidebar');
+        this.trigger(true);
+    },
+
+    onHide: function() {
+        console.log('Hiding left sidebar');
+        this.trigger(false);
     }
 });
 

--- a/app/js/stores/menu/rightSidebar.js
+++ b/app/js/stores/menu/rightSidebar.js
@@ -7,12 +7,19 @@ var RightSidebarActions = require('js/actions/menu/rightSidebar');
 
 var RightSidebarStore = Reflux.createStore({
     listenables: RightSidebarActions,
-    onToggle: function() {
-        console.log('Toggling right sidebar.');
-        $('.ui.sidebar.right')
-            .sidebar('setting', 'transition', 'overlay')
-            .sidebar('setting', 'duration', 300)
-            .sidebar('toggle');
+
+    getInitialState: function() {
+        return false;
+    },
+
+    onShow: function() {
+        console.log('Showing right sidebar');
+        this.trigger(true);
+    },
+
+    onHide: function() {
+        console.log('Hiding right sidebar');
+        this.trigger(false);
     }
 });
 


### PR DESCRIPTION
This PR improves the sidebars by implementing `show` and `hide` actions for them instead of the generic `toggle`. This also fixes the warnings about moving sidebars around in the DOM and the React root container message. These were both (apparently) being caused by Semantic deciding to move stuff around in the DOM and React getting confused.