### PR TITLE
Allow windows to be dragged from their title text

### DIFF
--- a/app/js/components/panel.jsx
+++ b/app/js/components/panel.jsx
@@ -66,9 +66,16 @@ var Panel = React.createClass({
                         lineHeight: '1.75',
                         marginLeft: 10,
                         paddingLeft: 10,
-                        width: this.props.width - 20
+                        width: this.props.width - 20,
+
+                        // Prevent anyone from selecting the text.
+                        MozUserSelect: 'none',
+                        WebkitUserSelect: 'none',
+                        MsUserSelect: 'none'
                     }}>
-                        {this.props.title}
+                        <span className="drag-handle">
+                            {this.props.title}
+                        </span>
 
                         <span
                             onClick={this.props.onClose}


### PR DESCRIPTION
This is a small fix. Previously, if you tried to drag a window around by dragging on top of the title text, the text would get selected and no movement would happen. This fixes that by hiding text selections in the title and making the *title text itself* one of the handles for dragging.